### PR TITLE
add event in method parameter. Stop error in console and save success attribute

### DIFF
--- a/view/adminhtml/web/js/customeroptionsreloader.js
+++ b/view/adminhtml/web/js/customeroptionsreloader.js
@@ -10,7 +10,7 @@ define([
         var elementSelector = 'select[name=attribute_id]';
         var containerIdSelector = '#customer-options-container';
 
-        $('body').on('change', elementSelector, function () {
+        $('body').on('change', elementSelector, function (event) {
             if (!$(containerIdSelector).length) {
                 $(elementSelector).after('<div id="customer-options-container"></div>');
             }


### PR DESCRIPTION
add this method parameter variable for stop error in console. This error occurs when mapping an existing client attribute. Instead of creating a new