### PR TITLE
Resolução de dois problemas na integração de pedidos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## 1.0.5 - 2019-09-11
+### Changed
+- ON-13820 Set customer taxvat on vat_id address field
+- ON-13821 Fix order importing when country code, on SkyHub addresses JSON's node, was 3 chars (ISO3)
+
 ## 1.0.4 - 2019-02-05
 ### Changed
-- Fixing the product's integration. Images wasn't been sent to skyhub. 
+- Fixing the product's integration. Images wasn't been sent to skyhub.
 
 ## 1.0.0 - 2018-08-09
 ### Added

--- a/Integration/Processor/Sales/Order.php
+++ b/Integration/Processor/Sales/Order.php
@@ -10,6 +10,7 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Model\Data\AddressFactory;
 use Magento\Customer\Api\Data\AddressInterface;
+use Magento\Directory\Model\CountryFactory;
 use Magento\Sales\Model\Order as SalesOrder;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
@@ -54,6 +55,9 @@ class Order extends AbstractProcessor
     /** @var AddressFactory */
     protected $addressFactory;
 
+    /** @var CountryFactory */
+    protected $countryFactory;
+
     /** @var CustomerInterfaceFactory */
     protected $customerFactory;
 
@@ -90,6 +94,7 @@ class Order extends AbstractProcessor
         CustomerRepositoryInterface $customerRepository,
         AddressRepositoryInterface $addressRepository,
         AddressFactory $addressFactory,
+        CountryFactory $countryFactory,
         CustomerInterfaceFactory $customerFactory,
         RegionInterfaceFactory $regionFactory,
         OrderCreatorFactory $orderCreatorFactory,
@@ -107,6 +112,7 @@ class Order extends AbstractProcessor
         $this->customerRepository    = $customerRepository;
         $this->addressRepository     = $addressRepository;
         $this->addressFactory        = $addressFactory;
+        $this->countryFactory        = $countryFactory;
         $this->customerFactory       = $customerFactory;
         $this->regionFactory         = $regionFactory;
         $this->orderCreatorFactory   = $orderCreatorFactory;
@@ -514,6 +520,10 @@ class Order extends AbstractProcessor
         /** @var \Magento\Customer\Api\Data\RegionInterface $region */
         $region = $this->regionFactory->create();
         $region->setRegion($addressObject->getData('region'));
+
+        if (strlen($country) > 2) {
+            $country = $this->countryFactory->create()->loadByCode($country)->getId();
+        }
         
         $address->setFirstname($customer->getFirstname())
             ->setLastname($customer->getLastname())

--- a/Integration/Processor/Sales/Order.php
+++ b/Integration/Processor/Sales/Order.php
@@ -489,6 +489,7 @@ class Order extends AbstractProcessor
     {
         /** @var AddressInterface $address */
         $address = $this->addressFactory->create();
+        $address->setVatId($customer->getTaxvat());
     
         $streetLinesCount = (int) $this->helperContext()
             ->scopeConfig()

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bittools/skyhub-m2",
     "type": "magento2-module",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "require": {
         "bittools/skyhub-php": "~1.2.0"
     },


### PR DESCRIPTION
- Em lojas cujo atributo **vat_id** (da entidade de endereço) é obrigatório, nenhum pedido estava sendo integrado. Corrigido no commit 9222517;
- Pedidos da CNova vêm com o código do país contendo três caracteres (ISO 3166 alpha-3), o que fazia o pedido não ser integrado. Este problema foi corrigido no commit cc6ba14, fazendo com que o módulo considere o código do país tanto com 2, como com 3 caracteres.