### PR TITLE
Update Product.php

### DIFF
--- a/Integration/Transformer/Catalog/Product.php
+++ b/Integration/Transformer/Catalog/Product.php
@@ -219,7 +219,7 @@ class Product extends AbstractProduct
                 case 'qty':
                 case 'price':
                 case 'promotional_price':
-                    continue;
+                    break;
                 default:
                     /** @var AttributeHelper $helper */
                     $helper = $this->context->objectManager()->get(AttributeHelper::class);
@@ -230,7 +230,7 @@ class Product extends AbstractProduct
                     }
                     
                     if (!$attribute) {
-                        continue;
+                        break;
                     }
                     
                     $value = $this->getProductAttributeValue($product, $attribute, $mappedAttribute->getCastType());


### PR DESCRIPTION
Continue on switch statement is deprecated causing an error when run `bin/magento setup:di:compile`, more information about this: 
https://wiki.php.net/rfc/continue_on_switch_deprecation

I changed `continue;` to `break;` but also works with `continue 2;`